### PR TITLE
Few cleanups and fixes in some of the trapdoor scripts

### DIFF
--- a/horton/gbasis/cext.pyx
+++ b/horton/gbasis/cext.pyx
@@ -734,27 +734,22 @@ cdef class GOBasis(GBasis):
 
         Parameters
         ----------
-        xyz : numpy-array of int
-              A integer (long) numpy-array with shape (3,) with the powers of x,y,z
-              in the integrals,
-              shape = (3,).
-
-        center : np.ndarray
-                 A numpy array of shape (3,) with the center [C_x, C_y, C_z] around which
-                 the moment integral is computed,
-                 shape = (3,).
-
+        xyz : numpy-array of int, shape=(3,).
+            A integer (long) numpy-array with shape (3,) with the powers of x,y,z in the
+            integrals.
+        center : np.ndarray, shape = (3,)
+            A numpy array of shape (3,) with the center [C_x, C_y, C_z] around which the
+            moment integral is computed.
         output : ``TwoIndex`` or ``LinalgFactory`` object
-                 When a ``TwoIndex`` instance is given, it is used as output
-                 argument and its contents are overwritten. When ``LinalgFactory``
-                 is given, it is used to construct the output ``TwoIndex``
-                 object. In both cases, the output two-index object is returned.
+            When a ``TwoIndex`` instance is given, it is used as output argument and its
+            contents are overwritten. When ``LinalgFactory`` is given, it is used to
+            construct the output ``TwoIndex`` object. In both cases, the output two-index
+            object is returned.
 
         Returns
         -------
         output : ``TwoIndex`` object
-                 The values of the integrals.
-
+            The values of the integrals.
         """
         # type checking
         assert xyz.flags['C_CONTIGUOUS']

--- a/horton/gbasis/ints.h
+++ b/horton/gbasis/ints.h
@@ -80,30 +80,49 @@ class GB2NuclearAttractionIntegral: public GB2Integral {
 };
 
 /** @brief
- Compute the (multipole) moment integrals in a Gaussian orbital basis.
-
- < gto_a | (x - C_x)^l (y - C_y)^m (z - C_z)^n | gto_b >.
+        Compute the (multipole) moment integrals in a Gaussian orbital basis.
+        < gto_a | (x - C_x)^l (y - C_y)^m (z - C_z)^n | gto_b >.
  */
 class GB2MomentIntegral: public GB2Integral {
     private:
-        long* xyz;
-        double* center;
+        long* xyz;          //!< Powers for x, y and z of the multipole moment.
+        double* center;     //!< The origin w.r.t. to which the multipole moment is computed.
 
     public:
-    /** @brief
-        Computes the moment integrals  < gto_a | (x - C_x)^l (y - C_y)^m (z - C_z)^n | gto_b >.
+        /** @brief
+                Initialize Moment integral calculator
 
-     @param max_shell_type
-        The highest angular momentum index suported
+            @param max_shell_type
+                The highest angular momentum index suported
 
-     @param xyz
-        The powers of x,y,z in the integrals (l, m, n).
+            @param xyz
+                The powers of x,y,z in the integrals (l, m, n).
 
-     @param center
-        The center [C_x, C_y, C_z] around which the moment integrals arecomputed
-     */
+            @param center
+                The center [C_x, C_y, C_z] around which the moment integrals arecomputed
+        */
         GB2MomentIntegral(long max_shell_type, long* xyz, double* center);
-        virtual void add(double coeff, double alpha0, double alpha1, const double* scales0, const double* scales1);
+
+        /** @brief
+                Add integrals for a pair of primite shells to the current contraction.
+
+            @param coeff
+                The contraction coefficient for the current primitive.
+
+            @param alpha0
+                The exponent of the primitive shell 0.
+
+            @param alpha1
+                The exponent of the primitive shell 1.
+
+            @param scales0
+                The normalization constants for the basis functions in primitive shell 0.
+
+            @param scales1
+                The normalization constants for the basis functions in primitive shell 1.
+          */
+        virtual void add(double coeff, double alpha0, double alpha1,
+                         const double* scales0, const double* scales1);
 };
 
 

--- a/horton/gbasis/test/test_ints.py
+++ b/horton/gbasis/test/test_ints.py
@@ -2188,7 +2188,7 @@ def test_nuclear_attraction_co_ccpv5z_cart_hf():
 
 
 def check_g09_dipole(fn_fchk, dipole_values):
-    """Compares dipole moment computed from WFN and nuclei to reference value.
+    """Compare dipole moment computed from WFN and nuclei to reference value.
 
     Parameters
     ----------
@@ -2239,7 +2239,7 @@ def test_dipole_co_ccpv5z_cart_hf():
 
 
 def check_g09_quadrupole(fn_fchk, quadrupole_values):
-    """Compares quadrupole moment computed from WFN and nuclei to reference value.
+    """Compare quadrupole moment computed from WFN and nuclei to reference value.
 
     Parameters
     ----------

--- a/horton/gbasis/test/test_ints.py
+++ b/horton/gbasis/test/test_ints.py
@@ -2188,6 +2188,15 @@ def test_nuclear_attraction_co_ccpv5z_cart_hf():
 
 
 def check_g09_dipole(fn_fchk, dipole_values):
+    """Compares dipole moment computed from WFN and nuclei to reference value.
+
+    Parameters
+    ----------
+    fn_fchk : str
+        The FCHK filename.
+    dipole_values : array, shape=(3,)
+        Three components of the expected dipole moment.
+    """
     mol = IOData.from_file(fn_fchk)
     xyz_array = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
     center = np.zeros(3)
@@ -2230,6 +2239,15 @@ def test_dipole_co_ccpv5z_cart_hf():
 
 
 def check_g09_quadrupole(fn_fchk, quadrupole_values):
+    """Compares quadrupole moment computed from WFN and nuclei to reference value.
+
+    Parameters
+    ----------
+    fn_fchk : str
+        The FCHK filename.
+    dipole_values : array, shape=(6,)
+        Six components of the expected dipole moment: x^2, y^2, z^2, xy, xz, yz
+    """
     mol = IOData.from_file(fn_fchk)
     xyz_array = np.array([[2, 0, 0], [0, 2, 0], [0, 0, 2], [1, 1, 0], [1, 0, 1], [0, 1, 1]])
     center = np.zeros(3)

--- a/tools/qa/simulate_trapdoor_pr.py
+++ b/tools/qa/simulate_trapdoor_pr.py
@@ -219,7 +219,9 @@ def trapdoor_workflow(repo, script, qaworkdir, skip_ancestor, rebuild):
     if rebuild:
         subprocess.check_call(['./setup.py', 'build_ext', '-i'])
     subprocess.check_call([script, 'feature'])
-    if not skip_ancestor:
+    if skip_ancestor:
+        subprocess.call([script, 'report'])
+    else:
         copied_script = os.path.join(qaworkdir, os.path.basename(script))
         shutil.copy(script, copied_script)
         shutil.copy('tools/qa/trapdoor.py', os.path.join(qaworkdir, 'trapdoor.py'))
@@ -229,8 +231,7 @@ def trapdoor_workflow(repo, script, qaworkdir, skip_ancestor, rebuild):
         if rebuild:
             subprocess.check_call(['./setup.py', 'build_ext', '-i'])
         subprocess.check_call([copied_script, 'ancestor'])
-        subprocess.check_call([copied_script, 'report'])
-    subprocess.check_call([script, 'report'])
+        subprocess.call([copied_script, 'report'])
 
 
 @log.section('roll back')

--- a/tools/qa/simulate_trapdoor_pr.py
+++ b/tools/qa/simulate_trapdoor_pr.py
@@ -212,18 +212,19 @@ def trapdoor_workflow(repo, script, qaworkdir, skip_ancestor):
     skip_ancestor : bool
                     If True, the trapdoor script is not executed in the ancestor.
     """
-    subprocess.call([script, 'feature'])
-    if skip_ancestor:
-        subprocess.call([script, 'report'])
-    else:
+    subprocess.check_call(['./setup.py', 'build_ext', '-i'])
+    subprocess.check_call([script, 'feature'])
+    if not skip_ancestor:
         copied_script = os.path.join(qaworkdir, os.path.basename(script))
         shutil.copy(script, copied_script)
         shutil.copy('tools/qa/trapdoor.py', os.path.join(qaworkdir, 'trapdoor.py'))
         # Check out the master branch. (We should be constructing the ancestor etc. but
         # that should come down to the same thing for a PR.)
         repo.heads.master.checkout()
-        subprocess.call([copied_script, 'ancestor'])
-        subprocess.call([copied_script, 'report'])
+        subprocess.check_call(['./setup.py', 'build_ext', '-i'])
+        subprocess.check_call([copied_script, 'ancestor'])
+        subprocess.check_call([copied_script, 'report'])
+    subprocess.check_call([script, 'report'])
 
 
 @log.section('roll back')

--- a/tools/qa/simulate_trapdoor_pr.py
+++ b/tools/qa/simulate_trapdoor_pr.py
@@ -181,8 +181,8 @@ def make_temporary_merge(repo, merge_head_name):
     log('Checkout new branch: %s.' % merge_head_name)
     merge_head.checkout()
     log('Merge with master.')
-    repo.index.merge_tree(repo.heads.master)
-    repo.index.merge_tree(merge_head)
+    merge_base = repo.merge_base(merge_head, repo.heads.master)
+    repo.index.merge_tree(repo.heads.master, base=merge_base)
     log('Check if merge went well.')
     unmerged_blobs = repo.index.unmerged_blobs()
     for _path, list_of_blobs in unmerged_blobs.iteritems():

--- a/tools/qa/trapdoor_cpplint.py
+++ b/tools/qa/trapdoor_cpplint.py
@@ -75,7 +75,8 @@ class CPPLintTrapdoorProgram(TrapdoorProgram):
         print 'USING              : cpplint.py update #456'
 
         # Call cpplint
-        command = [self.cpplint_file, '--linelength=100'] + get_source_filenames(config, 'cpp')
+        command = [self.cpplint_file, '--linelength=100', '--filter=-runtime/int']
+        command += get_source_filenames(config, 'cpp')
         output = run_command(command, has_failed=has_failed)[1]
 
         # Parse the output of cpplint into standard return values

--- a/tools/qa/trapdoor_doxygen.py
+++ b/tools/qa/trapdoor_doxygen.py
@@ -107,8 +107,12 @@ class DoxygenTrapdoorProgram(TrapdoorProgram):
                 if filename.startswith(prefix):
                     filename = filename[len(prefix):]
                 message = Message(filename, int(lineno), None, description)
-                counter[filename] += 1
-                messages.add(message)
+                # Sadly, doxygen sometimes generates duplicate messages for no good
+                # reason, which leads to incorrect counters and incorrectly failing tests.
+                # We need to check this explicitly...
+                if message not in messages:
+                    counter[filename] += 1
+                    messages.add(message)
         return counter, messages
 
 


### PR DESCRIPTION
@sfias @matt-chan

Summary of the changes to the multipole code (only silly things):
- Modified some docstring layout. Some of the examples I gave earlier were wrong. Apparently, the proper style is to indent the documentation by 4 spaces. Sorry... I had to look this up. Also no empty lines between different arguments, as far as I can tell.
- One doxygen addition and correction. 
- Auxiliary functions in the unit tests should be documented, which I did for the two new ones.

I did not fix the following: the datatype long at the C++ level. It would require changing to many other ones as well, which will break merges of old branches we still have to do.

The remaining commits are fixes in the trapdoor scripts that ran into while testing things locally.
